### PR TITLE
Issue-4: Update SDK to log in with a self managed wallet 

### DIFF
--- a/trings/ApplicationDelegates/AppDelegate.swift
+++ b/trings/ApplicationDelegates/AppDelegate.swift
@@ -19,9 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             configuration: .init(
                 walletAPIConfiguration: .init(
                     apiKey: "",
-                    rootURL: URL(string: "")!,
-                    rootWalletName: "",
-                    rootPassword: ""
+                    rootURL: URL(string: "")!
                 ),
                 authenticationServiceConfiguration: .init(
                     authorizationEndpoint: URL(string: "")!,

--- a/trings/UI/Views/SignIn/SignInViewModel.swift
+++ b/trings/UI/Views/SignIn/SignInViewModel.swift
@@ -41,8 +41,8 @@ class SignInViewModel {
     func signInWallet() {
         GreenstandWalletSDK.shared.signInWallet(walletName: walletName, password: password) { result in
             switch result {
-            case .success(let name):
-                self.coordinatorDelegate?.signInViewModel(self, didSignInWallet: name)
+            case .success:
+                self.coordinatorDelegate?.signInViewModel(self, didSignInWallet: self.walletName)
             case .failure(let error):
                 self.viewDelegate?.signInViewModel(self, didReceiveError: error)
             }


### PR DESCRIPTION
## Overview of changes

- wallet-ios-sdk has been updated to allow us to log in self managed wallets. We no longer require wallet-ios-sdk to be set-up with root wallet name and password. 

- This PR removes unused root wallet name and password parameters and updates 'signIn' completion. 

- Note -  wallet-ios-sdk version will need to be bumped and [PR](https://github.com/Greenstand/wallet-ios-sdk/pull/6) merged before merging this PR. 

- Ticket - https://github.com/Greenstand/wallet-ios-sdk/issues/4

- Related PR - https://github.com/Greenstand/wallet-ios-sdk/pull/6

## How was the change tested

- Received a token after entering a self managed wallet name and password.   

- Not currently been manually tested.

## Screenshots (if applicable)

- Not applicable.
